### PR TITLE
Modify country regex to allow spaces

### DIFF
--- a/findmepls.sh
+++ b/findmepls.sh
@@ -4,8 +4,8 @@
 RESP=$(curl -s ifconfig.me) \
 && curl -s "https://tools.keycdn.com/geo.json?host={$RESP}" | sed 's'/\
 '.*"ip":"\([.0-9:A-Fa-f]\{7,39\}\)",'\
-'.*"country_name":"\([a-zA-z]*\)",'\
-'.*"region_code":"\([a-zA-z]*\)",'\
+'.*"country_name":"\([a-zA-Z ]*\)",'\
+'.*"region_code":"\([a-zA-Z]*\)",'\
 '.*"city":"\([[:alpha:]]*\)",'\
 '.*$/'\
 '\1 - \4, \3, \2./'


### PR DESCRIPTION
"United Space" has a space, which is unrecognized by the regex. I added a space to allow countries that have spaces to be parsed.